### PR TITLE
Fix plugin crashes, compiling warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,6 @@ if(UNIX)
 	set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS OFF)
 endif()
 
-# removes the sprintf warnings from plugin-natives
-add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-
 set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/test/plugins)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})

--- a/lib/fopen_s/fopen_s.cpp
+++ b/lib/fopen_s/fopen_s.cpp
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <assert.h>
+#include <errno.h>
+#include "fopen_s.h"
+
+errno_t fopen_s(FILE **f, const char *name, const char *mode) {
+	errno_t ret = 0;
+	assert(f);
+	*f = fopen(name, mode);
+	/* Can't be sure about 1-to-1 mapping of errno and MS' errno_t */
+	if (!*f)
+		ret = errno;
+	return ret;
+}

--- a/lib/fopen_s/fopen_s.h
+++ b/lib/fopen_s/fopen_s.h
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <errno.h>
+
+#ifndef COMPAT_FOPEN_S_H
+#define COMPAT_FOPEN_S_H
+
+#ifndef _WIN32
+	typedef int errno_t;
+#endif
+
+errno_t fopen_s(FILE **f, const char *name, const char *mode);
+
+#endif /* COMPAT_FOPEN_S_H */

--- a/lib/strlcpy/strlcpy.cpp
+++ b/lib/strlcpy/strlcpy.cpp
@@ -1,0 +1,79 @@
+/* 
+ * $smu-mark$ 
+ * $name: strLcpy.c$ 
+ * $author: Nicolas Jombart <ecureuil@hsc.fr>$ 
+ * $copyright: Copyright (C) 1999 by Salvatore Sanfilippo$
+ * *copyright: (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>$ 
+ * $license: This software is under GPL version 2 of license$ 
+ * $date: Wed Feb 13 17:02:32 CET 2002$ 
+ * $rev:$ 
+ */ 
+
+/*      $OpenBSD: strlcpy.c,v 1.4 1999/05/01 18:56:41 millert Exp $     */
+
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+ * THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* $Id: strlcpy.c,v 1.1.1.1 2003/08/31 17:23:55 antirez Exp $ */
+
+/* This function comes from BSD */
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && \
+	!defined(__bsdi__) && !defined(__APPLE__)
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Copy src to string dst of size siz.  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz == 0).
+ * Returns strlen(src); if retval >= siz, truncation occurred.
+ */
+size_t strlcpy(char *dst, const char *src, size_t siz)
+{
+	register char *d = dst;
+	register const char *s = src;
+	register size_t n = siz;
+
+	/* Copy as many bytes as will fit */
+	if (n != 0 && --n != 0) {
+		do {
+			if ((*d++ = *s++) == 0)
+				break;
+		} while (--n != 0);
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src */
+	if (n == 0) {
+		if (siz != 0)
+			*d = '\0';              /* NUL-terminate dst */
+		while (*s++)
+			;
+	}
+
+	return(s - src - 1);    /* count does not include NUL */
+}
+
+#endif /* ! __*BSD__ */

--- a/lib/strlcpy/strlcpy.h
+++ b/lib/strlcpy/strlcpy.h
@@ -1,0 +1,6 @@
+#ifndef STRLCPY_H
+#define STRLCPY_H
+
+size_t strlcpy(char *dst, const char *src, size_t siz);
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,12 +6,22 @@ find_package(SAMPSDK REQUIRED)
 
 include_directories(
 	${SAMPSDK_INCLUDE_DIR}
+	${PROJECT_SOURCE_DIR}/lib/strlcpy
 )
+
+if(UNIX)
+	include_directories(
+		${PROJECT_SOURCE_DIR}/lib/fopen_s
+	)
+	set(FOPEN_FILE ${PROJECT_SOURCE_DIR}/lib/fopen_s/fopen_s.cpp)
+endif()
 
 add_samp_plugin(mapandreas
 	${SAMPSDK_DIR}/amxplugin.cpp
 	${SAMPSDK_DIR}/amxplugin2.cpp
 	${SAMPSDK_DIR}/amx/getch.c
+	${PROJECT_SOURCE_DIR}/lib/strlcpy/strlcpy.cpp
+	${FOPEN_FILE}
 	common.hpp
 	main.cpp
 	MapAndreas.cpp

--- a/src/MapAndreas.cpp
+++ b/src/MapAndreas.cpp
@@ -15,17 +15,23 @@ CMapAndreas::CMapAndreas()
 {
     m_iOperatingMode = MAP_ANDREAS_MODE_NONE;
     m_pPointData = NULL;
+    mapFile = NULL;
+    m_gridSize = 0.0f;
+}
+
+CMapAndreas::CMapAndreas(const CMapAndreas *other)
+{
+    this->mapFile = other->mapFile;
+    this->m_pPointData = other->m_pPointData;
+    this->m_gridSize = other->m_gridSize;
+    this->m_iOperatingMode = other->m_iOperatingMode;
 }
 
 //----------------------------------------------------------
 
 CMapAndreas::~CMapAndreas()
 {
-    m_iOperatingMode = MAP_ANDREAS_MODE_NONE;
-    if (m_pPointData) {
-        free(m_pPointData);
-    }
-    m_pPointData = NULL;
+    Unload();
 }
 
 //----------------------------------------------------------
@@ -33,132 +39,162 @@ CMapAndreas::~CMapAndreas()
 int CMapAndreas::Init(int iMode, char* cname, int len)
 {
     // check if already inited
-    if (m_iOperatingMode != MAP_ANDREAS_MODE_NONE) {
+    if (this->IsInited()) {
         return MAP_ANDREAS_ERROR_SUCCESS;
     }
 
-    char* name;
+    char name[MAP_ANDREAS_MAX_NAME];
+
     if (len > 1) {
-        name = cname;
-    } else {
+        strlcpy(name, cname, MAP_ANDREAS_MAX_NAME);
+    }
+    else {
         switch (iMode) {
         case MAP_ANDREAS_MODE_NOBUFFER:
         case MAP_ANDREAS_MODE_FULL:
-            name = MAP_ANDREAS_HMAP_FILE_FULL;
+            strlcpy(name, MAP_ANDREAS_HMAP_FILE_FULL, MAP_ANDREAS_MAX_NAME);
             break;
         case MAP_ANDREAS_MODE_MINIMAL:
-            name = MAP_ANDREAS_HMAP_FILE_MINIMAL;
+            strlcpy(name, MAP_ANDREAS_HMAP_FILE_MINIMAL, MAP_ANDREAS_MAX_NAME);
             break;
         }
     }
-
     if (iMode == MAP_ANDREAS_MODE_FULL) {
         // allocate the memory we need
-        m_pPointData = (unsigned short*)calloc(MAP_ANDREAS_POINTS_FULL, sizeof(unsigned short));
+        m_pPointData = (unsigned short *)calloc(MAP_ANDREAS_POINTS_FULL, sizeof(unsigned short));
         if (NULL == m_pPointData) {
             return MAP_ANDREAS_ERROR_MEMORY;
         }
 
         // load the file contents in to our point data buffer
-        FILE* fileInput = fopen(name, "rb");
+        FILE *fileInput = NULL;
+        fopen_s(&fileInput, name, "rb");
         if (NULL == fileInput) {
             return MAP_ANDREAS_ERROR_DATA_FILES;
         }
 
         fread(&m_pPointData[0], MAP_ANDREAS_POINTS_FULL, sizeof(unsigned short), fileInput);
+
         fclose(fileInput);
 
         m_iOperatingMode = MAP_ANDREAS_MODE_FULL;
         m_gridSize = MAP_ANDREAS_GRID_FULL;
         return MAP_ANDREAS_ERROR_SUCCESS;
-    } else if (iMode == MAP_ANDREAS_MODE_MINIMAL) {
-        m_pPointData = (unsigned short*)calloc(MAP_ANDREAS_POINTS_MINIMAL, sizeof(unsigned short));
+    }
+    else if (iMode == MAP_ANDREAS_MODE_MINIMAL) {
+        m_pPointData = (unsigned short *)calloc(MAP_ANDREAS_POINTS_MINIMAL, sizeof(unsigned short));
         if (NULL == m_pPointData) {
             return MAP_ANDREAS_ERROR_MEMORY;
         }
 
-        FILE* fileInput = fopen(name, "rb");
+        FILE *fileInput = NULL;
+        fopen_s(&fileInput, name, "rb");
         if (NULL == fileInput) {
             return MAP_ANDREAS_ERROR_DATA_FILES;
         }
 
         fread(&m_pPointData[0], MAP_ANDREAS_POINTS_MINIMAL, sizeof(unsigned short), fileInput);
+
         fclose(fileInput);
+
         m_iOperatingMode = MAP_ANDREAS_MODE_MINIMAL;
         m_gridSize = MAP_ANDREAS_GRID_MINIMAL;
-
         return MAP_ANDREAS_ERROR_SUCCESS;
-    } else if (iMode == MAP_ANDREAS_MODE_NOBUFFER) {
+    }
+    else if (iMode == MAP_ANDREAS_MODE_NOBUFFER) {
         m_iOperatingMode = MAP_ANDREAS_MODE_NOBUFFER;
         m_gridSize = MAP_ANDREAS_GRID_FULL;
-        m_pPointData = (unsigned short*)calloc(1, sizeof(unsigned short));
-        mapFile = fopen(name, "rb");
+        m_pPointData = (unsigned short *)calloc(1, sizeof(unsigned short));
+        fopen_s(&mapFile, name, "rb");
         if (NULL == mapFile) {
             return MAP_ANDREAS_ERROR_DATA_FILES;
         }
         return MAP_ANDREAS_ERROR_SUCCESS;
     }
 
-    logprintf("mode: %d", iMode);
-
     return MAP_ANDREAS_ERROR_FAILURE;
 }
 
 //----------------------------------------------------------
 
-float CMapAndreas::FindZ_For2DCoord(float X, float Y)
+float CMapAndreas::FindZ_For2DCoord(float X, float Y, int dataPos)
 {
-    // check for a co-ord outside the map
-    if (X < -3000.0f || X > 3000.0f || Y > 3000.0f || Y < -3000.0f) {
+    if (dataPos != -1) {
+        // get data
+        if (m_iOperatingMode == MAP_ANDREAS_MODE_FULL) {
+            return (float)m_pPointData[dataPos] / 100.0f; // the data is a float stored as ushort * 100
+        }
+        else if (m_iOperatingMode == MAP_ANDREAS_MODE_MINIMAL) {
+            return (float)m_pPointData[dataPos] / 100.0f;
+        }
+        else if (m_iOperatingMode == MAP_ANDREAS_MODE_NOBUFFER) {
+            // Jump to the position in the file and read it
+            fseek(mapFile, dataPos * sizeof(unsigned short), SEEK_SET);
+            fread(&m_pPointData[0], 1, sizeof(unsigned short), mapFile);
+
+            return (float)m_pPointData[0] / 100.0f;
+        }
         return 0.0f;
     }
+    else {
+        // check for a co-ord outside the map
+        if (X < -3000.0f || X > 3000.0f || Y > 3000.0f || Y < -3000.0f) {
+            return 0.0f;
+        }
 
-    // get row/col on 6000x6000 grid
-    int iGridX = ((int)X) + 3000;
-    int iGridY = (((int)Y) - 3000) * -1;
-    int iDataPos;
+        // get row/col on 6000x6000 grid
+        int iGridX = ((int)X) + 3000;
+        int iGridY = -(((int)Y) - 3000);
+        int iDataPos;
 
-    if (m_iOperatingMode == MAP_ANDREAS_MODE_FULL) {
-        iDataPos = (iGridY * 6000) + iGridX; // for every Y, increment by the number of cols, add the col index.
-        return (float)m_pPointData[iDataPos] / 100.0f; // the data is a float stored as ushort * 100
-    } else if (m_iOperatingMode == MAP_ANDREAS_MODE_MINIMAL) {
-        iDataPos = ((iGridY / 3) * 2000) + iGridX / 3; // skip every 2nd and 3rd line
-        return (float)m_pPointData[iDataPos] / 100.0f;
-    } else if (m_iOperatingMode == MAP_ANDREAS_MODE_NOBUFFER) {
-        iDataPos = (iGridY * 6000) + iGridX;
+        // get data
+        if (m_iOperatingMode == MAP_ANDREAS_MODE_FULL) {
+            iDataPos = (iGridY * 6000) + iGridX; // for every Y, increment by the number of cols, add the col index.
+            return (float)m_pPointData[iDataPos] / 100.0f; // the data is a float stored as ushort * 100
+        }
+        else if (m_iOperatingMode == MAP_ANDREAS_MODE_MINIMAL) {
+            iDataPos = ((iGridY / 3) * 2000) + iGridX / 3;    // skip every 2nd and 3rd line
+            return (float)m_pPointData[iDataPos] / 100.0f;
+        }
+        else if (m_iOperatingMode == MAP_ANDREAS_MODE_NOBUFFER) {
+            iDataPos = (iGridY * 6000) + iGridX;
 
-        // Jump to the position in the file and read it
-        fseek(mapFile, iDataPos * sizeof(unsigned short), SEEK_SET);
-        fread(&m_pPointData[0], 1, sizeof(unsigned short), mapFile);
+            // Jump to the position in the file and read it
+            fseek(mapFile, iDataPos * sizeof(unsigned short), SEEK_SET);
+            fread(&m_pPointData[0], 1, sizeof(unsigned short), mapFile);
 
-        return (float)m_pPointData[0] / 100.0f;
+            return (float)m_pPointData[0] / 100.0f;
+        }
+        return 0.0f;
     }
-
-    return 0.0f;
 }
 
 int CMapAndreas::SetZ_For2DCoord(float X, float Y, float z)
 {
     // check for a co-ord outside the map, or non-saveable z value
-    if (X < -3000.0f || X > 3000.0f || Y > 3000.0f || Y < -3000.0f || z < 0) {
+    if (X < -3000.0f || X > 3000.0f || Y > 3000.0f || Y < -3000.0f || z < 0.0f) {
         return 0;
     }
 
     // get row/col on 6000x6000 grid
     int iGridX = ((int)X) + 3000;
-    int iGridY = (((int)Y) - 3000) * -1;
+    int iGridY = -(((int)Y) - 3000);
     int iDataPos;
 
     if (m_iOperatingMode == MAP_ANDREAS_MODE_FULL) {
         iDataPos = (iGridY * 6000) + iGridX;
         m_pPointData[iDataPos] = (short)(z * 100.0f + 0.5); // Add 0.5 to round it properly
         return 1;
-    } else if (m_iOperatingMode == MAP_ANDREAS_MODE_MINIMAL) {
-        iDataPos = ((iGridY / 3) * 2000) + iGridX / 3; // skip every 2nd and 3rd line
-        m_pPointData[iDataPos] = (short)(z * 100.0f + 0.5); // Add 0.5 to round it properly
-        return 1;
-    } else if (m_iOperatingMode == MAP_ANDREAS_MODE_NOBUFFER) {
-        return 0;
+    }
+    else {
+        if (m_iOperatingMode == MAP_ANDREAS_MODE_MINIMAL) {
+            iDataPos = ((iGridY / 3) * 2000) + iGridX / 3;    // skip every 2nd and 3rd line
+            m_pPointData[iDataPos] = (short)(z * 100.0f + 0.5); // Add 0.5 to round it properly
+            return 1;
+        }
+        else if (m_iOperatingMode == MAP_ANDREAS_MODE_NOBUFFER) {
+            return 0;
+        }
     }
 
     return 0;
@@ -181,12 +217,14 @@ int CMapAndreas::SaveCurrentHMap(char* name)
         break;
     }
 
-    FILE* fileInput = fopen(name, "wb");
+    FILE *fileInput = NULL;
+    fopen_s(&fileInput, name, "wb");
     if (NULL == fileInput) {
         return MAP_ANDREAS_ERROR_DATA_FILES;
     }
 
     fwrite(&m_pPointData[0], values, sizeof(unsigned short), fileInput);
+
     fclose(fileInput);
 
     return 1;
@@ -194,35 +232,20 @@ int CMapAndreas::SaveCurrentHMap(char* name)
 
 float CMapAndreas::GetAverageZ(float x, float y)
 {
-    float p2;
-    float p3;
-    float xx;
-    float yy;
-
     // Get the Z value of 2 neighbor grids
     float p1 = FindZ_For2DCoord(x, y);
-    if (x < 0.0f) {
-        p2 = FindZ_For2DCoord(x + m_gridSize, y);
-    } else {
-        p2 = FindZ_For2DCoord(x - m_gridSize, y);
-    }
 
-    if (y < 0.0f) {
-        p3 = FindZ_For2DCoord(x, y + m_gridSize);
-    } else {
-        p3 = FindZ_For2DCoord(x, y - m_gridSize);
-    }
+    float p2 = FindZ_For2DCoord(x + (x < 0.0f ? m_gridSize : -m_gridSize), y);
+    float p3 = FindZ_For2DCoord(x, y + (y < 0.0f ? m_gridSize : -m_gridSize));
 
     // Filter the decimal part only
     double temp;
-    xx = (float)modf((double)x, &temp); // Linux compatibility
-    yy = (float)modf((double)y, &temp);
-
-    if (xx < 0) {
+    float xx = (float)modf((double)x, &temp); // Linux compatibility
+    float yy = (float)modf((double)y, &temp);
+    if (xx < 0.0f) {
         x = -xx;
     }
-
-    if (yy < 0) {
+    if (yy < 0.0f) {
         y = -yy;
     }
 
@@ -238,14 +261,27 @@ bool CMapAndreas::Unload()
     if (mapFile != NULL) {
         fclose(mapFile);
     }
-
     // Free the used memory
-    free(m_pPointData);
-
-    //m_pPointData = NULL;
+    if (m_pPointData) {
+        free(m_pPointData);
+        m_pPointData = NULL;
+    }
     m_iOperatingMode = MAP_ANDREAS_MODE_NONE;
-
     return true;
+}
+
+bool CMapAndreas::IsInited()
+{
+    // check if already inited
+    if (m_iOperatingMode != MAP_ANDREAS_MODE_NONE) {
+        return true;
+    }
+    return false;
+}
+
+int CMapAndreas::GetOperatingMode()
+{
+    return m_iOperatingMode;
 }
 
 //----------------------------------------------------------

--- a/src/MapAndreas.hpp
+++ b/src/MapAndreas.hpp
@@ -8,6 +8,11 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "strlcpy.h"
+
+#if LINUX
+	#include "fopen_s.h"
+#endif
 
 #include "common.hpp"
 
@@ -34,6 +39,7 @@
 #define MAP_ANDREAS_ERROR_MEMORY 2
 #define MAP_ANDREAS_ERROR_DATA_FILES 3
 
+#define MAP_ANDREAS_MAX_NAME 128
 //----------------------------------------------------------
 
 class CMapAndreas {
@@ -45,14 +51,17 @@ private:
 
 public:
     CMapAndreas();
+	CMapAndreas(const CMapAndreas *other);
     ~CMapAndreas();
 
     int Init(int iMode, char* cname, int len);
-    float FindZ_For2DCoord(float X, float Y);
+    float FindZ_For2DCoord(float X, float Y, int dataPos = -1);
     int SetZ_For2DCoord(float X, float Y, float z);
     int SaveCurrentHMap(char* name);
     float GetAverageZ(float x, float y);
     bool Unload();
+	bool IsInited();
+	int GetOperatingMode();
 };
 
 //----------------------------------------------------------

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 
 logprintf_t logprintf;
 
-extern "C" AMX_NATIVE_INFO nativeList[] = {
+AMX_NATIVE_INFO nativeList[] = {
     { "MapAndreas_Init", Natives::Init },
     { "MapAndreas_FindZ_For2DCoord", Natives::FindZ_For2DCoord },
     { "MapAndreas_FindAverageZ", Natives::FindAverageZ },


### PR DESCRIPTION
- Crashes like https://github.com/philip1337/samp-plugin-mapandreas/issues/4 should been fixed
- Removed _CRT_SECURE_NO_WARNINGS
- Fixed warnings and errors given by VS and GCC compilers, and by PVS-Studio
- Using safe `fopen_s` and `strlcpy` functions
- Added some missing stuff from MapAndreas 1.2.1 (for example #1 is are useless without `CMapAndreas(const CMapAndreas *other)` constructor)